### PR TITLE
Feat/add tracing id to log and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ The module model is explained [here](https://github.com/odrotbohm/moduliths#modu
 
 In the end it's about reducing accessibility of classes to a minimum, hiding internals of modules and preventing cyclic dependencies.  
 
+## Logging
+[Spring Sleuth](https://spring.io/projects/spring-cloud-sleuth) is included in this boilerplate to support trace ids which are added to all log messages that originate from a request. 
+Further, trace ids are also forwarded automatically to other services called by Spring's RestTemplate that are also based on this boilerplate or include Spring Sleuth. This means that distributed tracing is supported out of the box.     
 
 ## Application Monitoring
 A health-check endpoint is provided under `/actuator/health`

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ The module model is explained [here](https://github.com/odrotbohm/moduliths#modu
 In the end it's about reducing accessibility of classes to a minimum, hiding internals of modules and preventing cyclic dependencies.  
 
 ## Logging
-[Spring Sleuth](https://spring.io/projects/spring-cloud-sleuth) is included in this boilerplate to support trace ids which are added to all log messages that originate from a request. 
-Further, trace ids are also forwarded automatically to other services called by Spring's RestTemplate that are also based on this boilerplate or include Spring Sleuth. This means that distributed tracing is supported out of the box.     
+[Spring Sleuth](https://spring.io/projects/spring-cloud-sleuth) is included in this boilerplate to support trace ids which are added to all log messages that originate from a request.
+The logging format will be added with the following information [application name,trace id, span id]. The application name got read from the SPRING_APPLICATION_NAME environment variable.
+<pre><code>2020-10-21 12:01:16.285  INFO <b>[myProjectName-service,0b6aaf642574edd3,0b6aaf642574edd3]</b> 289589 --- [nio-9000-exec-1] Example              : Hello world!
+</code></pre>
+Further, trace ids are also forwarded automatically to other services called by Spring's RestTemplate or JmsTemplate that are also based on this boilerplate or include Spring Sleuth. This means that distributed tracing is supported out of the box.     
 
 ## Application Monitoring
 A health-check endpoint is provided under `/actuator/health`

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ plugins {
 	id "com.gorylenko.gradle-git-properties" version "2.2.4"
 }
 
+ext {
+	set('springCloudVersion', "2020.0.2")
+}
+
+
 group = 'com.myCompanyName.myProjectName'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '15'
@@ -26,6 +31,7 @@ dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-actuator'
 	compile 'org.springframework.boot:spring-boot-starter-hateoas'
 	compile 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
 
 	// add to fix incompatibility of spring boot
 	compile 'org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE'
@@ -41,6 +47,12 @@ dependencies {
 
 	testCompile('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+	}
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-actuator'
 	compile 'org.springframework.boot:spring-boot-starter-hateoas'
 	compile 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+	compile 'org.springframework.cloud:spring-cloud-starter-sleuth'
 
 	// add to fix incompatibility of spring boot
 	compile 'org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE'

--- a/doc/adr/0007-use-spring-sleuth-for-tracing.md
+++ b/doc/adr/0007-use-spring-sleuth-for-tracing.md
@@ -1,0 +1,18 @@
+# Distributed Tracing
+
+## Context and Problem Statement
+How can we trace requests within the log of a service or even over multiple services? 
+This is essential when analysing errors in distributed systems which contain of multiple services communicating with each other. 
+
+## Considered Options
+
+* Spring Sleuth library
+* other tracing libraries
+* Self-implemented tracing and error ids
+
+## Decision Outcome
+
+Chosen option: "Spring Sleuth", because 
+
+* it harmonises perfectly with Spring Boot
+* it provides all desired behaviour out of the box without any additional configuration needed

--- a/scripts/init-script/init.js
+++ b/scripts/init-script/init.js
@@ -39,6 +39,7 @@ function sanitize(input) {
 
 const filesForSearchAndReplace = [
   '../../src/**/**.java',
+  '../../src/**/**.properties',
   '../../api/**',
   '../../build.gradle',
   '../../settings.gradle',

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
@@ -1,13 +1,25 @@
 package com.myCompanyName.myProjectName.common.rest.error;
 
-import com.myCompanyName.myProjectName.generated.model.Error;
-import java.util.UUID;
+import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.stereotype.Component;
 
+import com.myCompanyName.myProjectName.generated.model.Error;
+
+@Component
 public class RestErrorBuilder {
 
+  private Tracer tracer;
+
+  public RestErrorBuilder(final Tracer tracer) {
+    this.tracer = tracer;
+  }
+
   public Error buildError(Exception e, RestErrorCode errorCode) {
+    // get spring sleuth trace id
+    String errorId = tracer.currentSpan().context().traceId();
+
     return new Error()
-        .id(UUID.randomUUID().toString())
+        .id(errorId)
         .code(errorCode.getErrorCode())
         .message(e.getMessage());
   }

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
@@ -1,27 +1,35 @@
 package com.myCompanyName.myProjectName.common.rest.error;
 
+import java.util.UUID;
+
+import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.stereotype.Component;
 
 import com.myCompanyName.myProjectName.generated.model.Error;
 
+import static java.util.Objects.nonNull;
+
 @Component
 public class RestErrorBuilder {
 
-  private Tracer tracer;
+    private Tracer tracer;
 
-  public RestErrorBuilder(final Tracer tracer) {
-    this.tracer = tracer;
-  }
+    public RestErrorBuilder(final Tracer tracer) {
+        this.tracer = tracer;
+    }
 
-  public Error buildError(Exception e, RestErrorCode errorCode) {
-    // get spring sleuth trace id
-    String errorId = tracer.currentSpan().context().traceId();
+    public Error buildError(Exception e, RestErrorCode errorCode) {
+        String errorId;
+        // get spring sleuth trace id
+        Span currentSpan = tracer.currentSpan();
+        if (nonNull(currentSpan)) {
+            errorId = currentSpan.context().traceId();
+        } else {
+            errorId = UUID.randomUUID().toString();
+        }
 
-    return new Error()
-        .id(errorId)
-        .code(errorCode.getErrorCode())
-        .message(e.getMessage());
-  }
+        return new Error().id(errorId).code(errorCode.getErrorCode()).message(e.getMessage());
+    }
 
 }

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilder.java
@@ -13,7 +13,7 @@ import static java.util.Objects.nonNull;
 @Component
 public class RestErrorBuilder {
 
-    private Tracer tracer;
+    private final Tracer tracer;
 
     public RestErrorBuilder(final Tracer tracer) {
         this.tracer = tracer;

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorLogger.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorLogger.java
@@ -3,7 +3,9 @@ package com.myCompanyName.myProjectName.common.rest.error;
 import com.myCompanyName.myProjectName.generated.model.Error;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RestErrorLogger {
 
   private static final Logger logger = LoggerFactory.getLogger(RestExceptionHandler.class);

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandler.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandler.java
@@ -14,8 +14,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 public class RestExceptionHandler {
 
-  private RestErrorBuilder restErrorBuilder = new RestErrorBuilder();
-  private RestErrorLogger restErrorLogger = new RestErrorLogger();
+  private RestErrorBuilder restErrorBuilder;
+  private RestErrorLogger restErrorLogger;
+
+  public RestExceptionHandler(final RestErrorBuilder restErrorBuilder, final RestErrorLogger restErrorLogger) {
+    this.restErrorBuilder = restErrorBuilder;
+    this.restErrorLogger = restErrorLogger;
+  }
 
   @ExceptionHandler({Exception.class})
   @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandler.java
+++ b/src/main/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandler.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 public class RestExceptionHandler {
 
-  private RestErrorBuilder restErrorBuilder;
-  private RestErrorLogger restErrorLogger;
+  private final RestErrorBuilder restErrorBuilder;
+  private final RestErrorLogger restErrorLogger;
 
   public RestExceptionHandler(final RestErrorBuilder restErrorBuilder, final RestErrorLogger restErrorLogger) {
     this.restErrorBuilder = restErrorBuilder;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
+spring.application.name=myProjectName-service
+
 management.endpoints.web.exposure.include=*

--- a/src/test/java/com/myCompanyName/myProjectName/authors/rest/AuthorsControllerTest.java
+++ b/src/test/java/com/myCompanyName/myProjectName/authors/rest/AuthorsControllerTest.java
@@ -11,10 +11,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 
-public class AuthorsControllerTest {
+class AuthorsControllerTest {
 
   @Test
-  public void WHEN_get_authors_THEN_response_is_not_null() {
+  void WHEN_get_authors_THEN_response_is_not_null() {
     // Arrange
     AuthorController authorController = new AuthorController();
 
@@ -26,7 +26,7 @@ public class AuthorsControllerTest {
   }
 
   @Test
-  public void WHEN_get_authors_THEN_response_contains_list_of_authors() {
+  void WHEN_get_authors_THEN_response_contains_list_of_authors() {
     // Arrange
     AuthorController authorController = new AuthorController();
 
@@ -40,7 +40,7 @@ public class AuthorsControllerTest {
   }
 
   @Test
-  public void WHEN_get_author_by_id_THEN_response_is_not_null() {
+  void WHEN_get_author_by_id_THEN_response_is_not_null() {
     // Arrange
     AuthorController authorController = new AuthorController();
 
@@ -52,7 +52,7 @@ public class AuthorsControllerTest {
   }
 
   @Test
-  public void WHEN_get_author_by_id_THEN_response_contains_author_with_data() {
+  void WHEN_get_author_by_id_THEN_response_contains_author_with_data() {
     // Arrange
     AuthorController authorController = new AuthorController();
 

--- a/src/test/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilderTest.java
+++ b/src/test/java/com/myCompanyName/myProjectName/common/rest/error/RestErrorBuilderTest.java
@@ -1,0 +1,90 @@
+package com.myCompanyName.myProjectName.common.rest.error;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceContext;
+import org.springframework.cloud.sleuth.Tracer;
+
+import com.myCompanyName.myProjectName.generated.model.Error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RestErrorBuilderTest {
+
+    private static final String ANY_TRACE_ID = "traceId";
+    private static final String ANY_EXCEPTION_MESSAGE = "exceptionMessage";
+    private static final RestErrorCode ANY_ERROR_CODE = RestErrorCode.SERVER_ERROR;
+
+    @InjectMocks
+    private RestErrorBuilder restErrorBuilder;
+
+    @Mock
+    private Tracer tracer;
+
+    @BeforeEach
+    void setup() {
+        Span span = mock(Span.class);
+        when(tracer.currentSpan()).thenReturn(span);
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.traceId()).thenReturn(ANY_TRACE_ID);
+        when(span.context()).thenReturn(traceContext);
+    }
+
+    @Test
+    void WHEN_buildError_THEN_current_traceId_is_loaded() {
+        // Arrange
+        Exception e = mock(Exception.class);
+
+        // Act
+        restErrorBuilder.buildError(e, ANY_ERROR_CODE);
+
+        // Assert
+        verify(tracer.currentSpan().context()).traceId();
+    }
+
+    @Test
+    void WHEN_buildError_THEN_error_id_equals_current_traceId() {
+        // Arrange
+        Exception e = mock(Exception.class);
+
+        // Act
+        Error error = restErrorBuilder.buildError(e, ANY_ERROR_CODE);
+
+        // Assert
+        assertThat(error.getId()).isEqualTo(ANY_TRACE_ID);
+    }
+
+    @Test
+    void GIVEN_restError_WHEN_buildError_THEN_error_code_equals_restErrorCode() {
+        // Arrange
+        Exception e = mock(Exception.class);
+
+        // Act
+        Error error = restErrorBuilder.buildError(e, ANY_ERROR_CODE);
+
+        // Assert
+        assertThat(error.getCode()).isEqualTo(ANY_ERROR_CODE.getErrorCode());
+    }
+
+    @Test
+    void GIVEN_exception_WHEN_buildError_THEN_error_message_equals_exceptionMessage() {
+        // Arrange
+        Exception e = mock(Exception.class);
+        when(e.getMessage()).thenReturn(ANY_EXCEPTION_MESSAGE);
+
+        // Act
+        Error error = restErrorBuilder.buildError(e, ANY_ERROR_CODE);
+
+        // Assert
+        assertThat(error.getMessage()).isEqualTo(ANY_EXCEPTION_MESSAGE);
+    }
+}

--- a/src/test/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandlerTest.java
+++ b/src/test/java/com/myCompanyName/myProjectName/common/rest/error/RestExceptionHandlerTest.java
@@ -1,0 +1,58 @@
+package com.myCompanyName.myProjectName.common.rest.error;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.myCompanyName.myProjectName.generated.model.Error;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RestExceptionHandlerTest {
+
+    @InjectMocks
+    private RestExceptionHandler restExceptionHandler;
+
+    @Mock
+    private RestErrorBuilder restErrorBuilder;
+
+    @Mock
+    private RestErrorLogger restErrorLogger;
+
+    @BeforeEach
+    void setup() {
+        when(restErrorBuilder.buildError(any(), any())).thenReturn(mock(Error.class));
+    }
+
+    @Test
+    void WHEN_exception_THEN_restErrorBuilder_is_called() {
+        // Arrange
+        Exception e = mock(Exception.class);
+
+        // Act
+        restExceptionHandler.exception(e);
+
+        // Assert
+        verify(restErrorBuilder).buildError(eq(e), any());
+    }
+
+    @Test
+    void WHEN_exception_THEN_restErrorLogger_is_called() {
+        // Arrange
+        Exception e = mock(Exception.class);
+
+        // Act
+        restExceptionHandler.exception(e);
+
+        // Assert
+        verify(restErrorLogger).log(eq(e), any());
+    }
+}


### PR DESCRIPTION
Add Spring Sleuth to have tracing Ids in log messages and support distributed tracing.
Also use traceIds as ids for error response objects. 